### PR TITLE
[Fix] 当自定义 dismiss 的手势动画的时候产生的误判

### DIFF
--- a/MLeaksFinder/UIViewController+MemoryLeak.m
+++ b/MLeaksFinder/UIViewController+MemoryLeak.m
@@ -53,7 +53,7 @@ const void *const kHasBeenPoppedKey = &kHasBeenPoppedKey;
     
     if (!dismissedViewController) return;
     
-    [dismissedViewController willDealloc];
+    objc_setAssociatedObject(self, kHasBeenPoppedKey, @(YES), OBJC_ASSOCIATION_RETAIN);
 }
 
 - (BOOL)willDealloc {


### PR DESCRIPTION
和 pop 手势一样处理 dismiss 的逻辑